### PR TITLE
GH-28: Add network support for ideviceinfo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,6 +58,7 @@
         "streambuf": "c",
         "cinttypes": "c",
         "cstdbool": "c",
-        "typeinfo": "c"
+        "typeinfo": "c",
+        "common_binding.h": "c"
     }
 }

--- a/examples/idevice_id.js
+++ b/examples/idevice_id.js
@@ -1,6 +1,6 @@
 const imobiledevice = require('../index');
 
-imobiledevice.id({debug: true, usblist: false, networklist: true}, (error, info) => {
+imobiledevice.id({debug: false, usblist: true, networklist: false}, (error, info) => {
     if (error) {
         console.error(`Error in callign idevice id: ${error}`);
     } else {

--- a/examples/ideviceinfo_default.js
+++ b/examples/ideviceinfo_default.js
@@ -2,9 +2,6 @@ const imobiledevice = require('../index');
 
 
 imobiledevice.info({}, (error, info) => {
-    if (error) {
-        console.error(`Error in callign ideviceinfo: ${error}`);
-    } else {
-        console.log(`ideviceinfo: ${info}`);
-    }
+    console.error('Error in callign ideviceinfo: ', error);
+    console.log('ideviceinfo: ', info);
 });

--- a/examples/ideviceinfo_with_options.js
+++ b/examples/ideviceinfo_with_options.js
@@ -2,11 +2,12 @@ const imobiledevice = require('../index');
 
 imobiledevice.info({
     debug: true,
-    domain: "com.apple.mobile.battery"
+    domain: "com.apple.mobile.battery",
+    network: true
 }, (error, info) => {
-    if (error) {
-        console.error(`Error in callign ideviceinfo: ${error}`);
+    if(error) {
+        console.error('Error in callign ideviceinfo: ', error);
     } else {
-        console.log(`ideviceinfo: ${info}`);
+        console.log('ideviceinfo: ', info);
     }
 });

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,150 @@
+
+const native_lockdown_errors = {
+    LOCKDOWN_E_SUCCESS                                :   0,
+	LOCKDOWN_E_INVALID_ARG                            :  -1,
+	LOCKDOWN_E_INVALID_CONF                           :  -2,
+	LOCKDOWN_E_PLIST_ERROR                            :  -3,
+	LOCKDOWN_E_PAIRING_FAILED                         :  -4,
+	LOCKDOWN_E_SSL_ERROR                              :  -5,
+	LOCKDOWN_E_DICT_ERROR                             :  -6,
+	LOCKDOWN_E_RECEIVE_TIMEOUT                        :  -7,
+	LOCKDOWN_E_MUX_ERROR                              :  -8,
+	LOCKDOWN_E_NO_RUNNING_SESSION                     :  -9,
+	LOCKDOWN_E_INVALID_RESPONSE                       : -10,
+	LOCKDOWN_E_MISSING_KEY                            : -11,
+	LOCKDOWN_E_MISSING_VALUE                          : -12,
+	LOCKDOWN_E_GET_PROHIBITED                         : -13,
+	LOCKDOWN_E_SET_PROHIBITED                         : -14,
+	LOCKDOWN_E_REMOVE_PROHIBITED                      : -15,
+	LOCKDOWN_E_IMMUTABLE_VALUE                        : -16,
+	LOCKDOWN_E_PASSWORD_PROTECTED                     : -17,
+	LOCKDOWN_E_USER_DENIED_PAIRING                    : -18,
+	LOCKDOWN_E_PAIRING_DIALOG_RESPONSE_PENDING        : -19,
+	LOCKDOWN_E_MISSING_HOST_ID                        : -20,
+	LOCKDOWN_E_INVALID_HOST_ID                        : -21,
+	LOCKDOWN_E_SESSION_ACTIVE                         : -22,
+	LOCKDOWN_E_SESSION_INACTIVE                       : -23,
+	LOCKDOWN_E_MISSING_SESSION_ID                     : -24,
+	LOCKDOWN_E_INVALID_SESSION_ID                     : -25,
+	LOCKDOWN_E_MISSING_SERVICE                        : -26,
+	LOCKDOWN_E_INVALID_SERVICE                        : -27,
+	LOCKDOWN_E_SERVICE_LIMIT                          : -28,
+	LOCKDOWN_E_MISSING_PAIR_RECORD                    : -29,
+	LOCKDOWN_E_SAVE_PAIR_RECORD_FAILED                : -30,
+	LOCKDOWN_E_INVALID_PAIR_RECORD                    : -31,
+	LOCKDOWN_E_INVALID_ACTIVATION_RECORD              : -32,
+	LOCKDOWN_E_MISSING_ACTIVATION_RECORD              : -33,
+	LOCKDOWN_E_SERVICE_PROHIBITED                     : -34,
+	LOCKDOWN_E_ESCROW_LOCKED                          : -35,
+	LOCKDOWN_E_PAIRING_PROHIBITED_OVER_THIS_CONNECTION: -36,
+	LOCKDOWN_E_FMIP_PROTECTED                         : -37,
+	LOCKDOWN_E_MC_PROTECTED                           : -38,
+	LOCKDOWN_E_MC_CHALLENGE_REQUIRED                  : -39,
+	LOCKDOWN_E_UNKNOWN_ERROR                          : -256
+};
+
+const native_idevice_errors = {
+	IDEVICE_E_SUCCESS        :  0,
+	IDEVICE_E_INVALID_ARG    : -1,
+	IDEVICE_E_UNKNOWN_ERROR  : -2,
+	IDEVICE_E_NO_DEVICE      : -3,
+	IDEVICE_E_NOT_ENOUGH_DATA: -4,
+	IDEVICE_E_SSL_ERROR      : -6,
+	IDEVICE_E_TIMEOUT        : -7
+}
+
+const native_lockdown_errors_dict = {
+	'0'  : 'LOCKDOWN_E_SUCCESS',                                
+	'-1' : 'LOCKDOWN_E_INVALID_ARG',
+	'-2' : 'LOCKDOWN_E_INVALID_CONF',                           
+	'-3' : 'LOCKDOWN_E_PLIST_ERROR',                        
+	'-4' : 'LOCKDOWN_E_PAIRING_FAILED',                         
+	'-5' : 'LOCKDOWN_E_SSL_ERROR',                       
+	'-6' : 'LOCKDOWN_E_DICT_ERROR',                            
+	'-7' : 'LOCKDOWN_E_RECEIVE_TIMEOUT',
+	'-8' : 'LOCKDOWN_E_MUX_ERROR',                      
+	'-9' : 'LOCKDOWN_E_NO_RUNNING_SESSION',
+	'-10': 'LOCKDOWN_E_INVALID_RESPONSE',                   
+	'-11': 'LOCKDOWN_E_MISSING_KEY',                     
+	'-12': 'LOCKDOWN_E_MISSING_VALUE',                          
+	'-13': 'LOCKDOWN_E_GET_PROHIBITED',                        
+	'-14': 'LOCKDOWN_E_SET_PROHIBITED ',                       
+	'-15': 'LOCKDOWN_E_REMOVE_PROHIBITED',                      
+	'-16': 'LOCKDOWN_E_IMMUTABLE_VALUE',                     
+	'-17': 'LOCKDOWN_E_PASSWORD_PROTECTED',                     
+	'-18': 'LOCKDOWN_E_USER_DENIED_PAIRING',                   
+	'-19': 'LOCKDOWN_E_PAIRING_DIALOG_RESPONSE_PENDING',
+	'-20': 'LOCKDOWN_E_MISSING_HOST_ID',      
+	'-21': 'LOCKDOWN_E_INVALID_HOST_ID',                      
+	'-22': 'LOCKDOWN_E_SESSION_ACTIVE',                      
+	'-23': 'LOCKDOWN_E_SESSION_INACTIVE',                       
+	'-24': 'LOCKDOWN_E_MISSING_SESSION_ID',                     
+	'-25': 'LOCKDOWN_E_INVALID_SESSION_ID',                   
+	'-26': 'LOCKDOWN_E_MISSING_SERVICE',                   
+	'-27': 'LOCKDOWN_E_INVALID_SERVICE',                      
+	'-28': 'LOCKDOWN_E_SERVICE_LIMIT',                      
+	'-29': 'LOCKDOWN_E_MISSING_PAIR_RECORD',                    
+	'-30': 'LOCKDOWN_E_SAVE_PAIR_RECORD_FAILED',
+	'-31': 'LOCKDOWN_E_INVALID_PAIR_RECORD',              
+	'-32': 'LOCKDOWN_E_INVALID_ACTIVATION_RECORD',
+	'-33': 'LOCKDOWN_E_MISSING_ACTIVATION_RECORD',            
+	'-34': 'LOCKDOWN_E_SERVICE_PROHIBITED',            
+	'-35': 'LOCKDOWN_E_ESCROW_LOCKED',                   
+	'-36': 'LOCKDOWN_E_PAIRING_PROHIBITED_OVER_THIS_CONNECTION',
+	'-37': 'LOCKDOWN_E_FMIP_PROTECTED',
+	'-38': 'LOCKDOWN_E_MC_PROTECTED',                       
+	'-39': 'LOCKDOWN_E_MC_CHALLENGE_REQUIRED',                  
+	'-256': 'LOCKDOWN_E_UNKNOWN_ERROR'                
+};
+
+/**
+ * Libimobiledevice lockdown error.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name
+ * @property {string} type - The different type of lockdown errors as string defined in native_lockdown_errors_dict
+ * @property {number} code - The different code errors of lockdown as a number.
+ */
+exports.LockdownError = class LockdownError extends Error {
+    constructor(message, code) {
+        super(message);
+		this.name = 'LockdownError';
+        this.type = native_lockdown_errors_dict[code];
+        this.code = code;
+    }
+};
+
+/**
+ * Libimobiledevice idevice error. If this error is returned by info, pair or backup2 
+ * methods means that no device has been found.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name
+ * @property {number} code
+ */
+exports.IdeviceNoDeviceFoundError = class IdeviceNoDeviceFoundError extends Error {
+    constructor(message) {
+        super(message);
+		this.name = 'IdeviceNoDeviceFoundError';
+        this.code = native_idevice_errors.IDEVICE_E_NO_DEVICE;
+    }
+}
+
+/**
+ * Error representing an unkown error generated by libimobiledevice.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name
+ */
 exports.UnkownErrror = class UnkownError extends Error {
     constructor(message) {
         super(`Unkown error: ${message}`);
-        this.name
+        this.name = 'UnkownErrror';
     }
-}
+};
+
+exports.native_lockdown_errors = native_lockdown_errors;
+exports.native_idevice_errors = native_idevice_errors;

--- a/lib/idevice_id.js
+++ b/lib/idevice_id.js
@@ -8,6 +8,14 @@ const native_id_errors = {
     ID_E_CANNOT_REALLOC_MEMORY: -3
 }
 
+/**
+ * Error representing that any divice has been found.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name
+ * @property {number} code
+ */
 class CannotRetrieveDeviceListError extends Error {
     constructor() {
         super("ERROR: Cannot retrieve device list");
@@ -16,6 +24,14 @@ class CannotRetrieveDeviceListError extends Error {
     }
 }
 
+/**
+ * Error representing a memory error from libimobiledevice which can't alloc memory.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name
+ * @property {number} code
+ */
 class CannotMallocMemoryError extends Error {
     constructor() {
         super("ERROR: Cannot malloc memory");
@@ -24,6 +40,14 @@ class CannotMallocMemoryError extends Error {
     }
 }
 
+/**
+ * Error representing a memory error from libimobiledevice which can't realloc memory.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name
+ * @property {number} code
+ */
 class CannotReallocMemoryError extends Error {
     constructor() {
         super("ERROR: Cannot realloc memory");

--- a/lib/idevice_info.js
+++ b/lib/idevice_info.js
@@ -1,0 +1,72 @@
+const cp = require('child_process');
+const { LockdownError, native_lockdown_errors, native_idevice_errors, IdeviceNoDeviceFoundError } = require('./errors');
+const plist = require('plist');
+
+const native_idevice_info_errors = {
+    INFO_E_ESUCCESS: 0,
+    INFO_E_INVALID_DOMAIN: -1,
+    INFO_E_UNKOWN_ERROR: -2
+}
+
+class InfoInvalidDomainError extends Error {
+    constructor(message) {
+        super(message);
+        this.code = native_idevice_info_errors.INFO_E_INVALID_DOMAIN;
+    }
+}
+
+class InfoUnkownError extends Error {
+    constructor(message, infoCode, ideviceError, lockdownCode) {
+        super(message);
+        this.infoCode = infoCode;
+		this.ideviceError = ideviceError;
+		this.lockdownCode = lockdownCode;
+    }
+}
+
+exports.InfoInvalidDomainError = InfoInvalidDomainError;
+exports.InfoUnkownError = InfoUnkownError;
+exports.native_idevice_info_errors = native_idevice_info_errors;
+
+exports.idevice_info = function(options, callback) {
+	if (typeof options === "function") {
+		callback = options;
+		options = null;
+	}
+
+	options = options || {};
+
+	const child = cp.fork(`${__dirname}/workers/info_worker`);
+	child.send(options)
+	child.on('message', res => {
+		let infoError = res.error.infoError;
+		let ideviceError = res.error.ideviceError;
+		let lockdownError = res.error.lockdownError;
+		let errorMessage = res.error.errorMessage;
+		switch(true) {
+			case (infoError === native_idevice_info_errors.INFO_E_ESUCCESS &&
+					ideviceError === native_idevice_errors.IDEVICE_E_SUCCESS &&
+					lockdownError === native_lockdown_errors.LOCKDOWN_E_SUCCESS):
+				callback(null, res.data ? plist.parse(res.data) : {});
+				break;
+			case (ideviceError === native_idevice_errors.IDEVICE_E_NO_DEVICE):
+				callback(new IdeviceNoDeviceFoundError(errorMessage), null);
+				break;
+			case (infoError === native_idevice_info_errors.INFO_E_INVALID_DOMAIN):
+				callback(new InfoInvalidDomainError(errorMessage), null);
+				break;
+			case (infoError === native_idevice_info_errors.INFO_E_UNKOWN_ERROR &&
+					ideviceError === native_idevice_errors.IDEVICE_E_SUCCESS && 
+					lockdownError !== native_lockdown_errors.LOCKDOWN_E_SUCCESS):
+				callback(new LockdownError(errorMessage, lockdownError), null);
+				break;
+			default:
+				callback(new InfoUnkownError(errorMessage, infoError, ideviceError, lockdownError), null);
+				break;
+
+		}
+		child.disconnect()
+	})
+	return child
+
+}

--- a/lib/info_worker.js
+++ b/lib/info_worker.js
@@ -1,8 +1,0 @@
-const lib = require(`${__dirname}/../build/Release/imobiledevice.node`)
-
-process.on('message', options => {
-	lib.idevice_info(options, (err, data) => {
-		if (err) process.send({err: err})
-		else process.send({data: data})
-	})
-})

--- a/lib/workers/info_worker.js
+++ b/lib/workers/info_worker.js
@@ -1,0 +1,7 @@
+const lib = require(`${__dirname}/../../build/Release/imobiledevice.node`)
+
+process.on('message', options => {
+	lib.idevice_info(options, (error, data) => {
+		process.send({error: error, data: data});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "node-gyp": "^8.0.0",
+    "plist": "^3.0.2",
     "shelljs": "^0.8.3"
   },
   "scripts": {

--- a/src/idevice/info.h
+++ b/src/idevice/info.h
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include "common/common_binding.h"
+#include <libimobiledevice/libimobiledevice.h>
+#include <libimobiledevice/lockdown.h>
 
 struct idevice_info_options {
     bool debug;
@@ -11,8 +13,27 @@ struct idevice_info_options {
     char *udid;
     char *domain;
     char *key;
+    bool network;
 };
 
-void idevice_info(struct idevice_info_options options, FILE *stream_err, FILE *stream_out);
+typedef enum {
+    INFO_E_ESUCCESS = 0,
+    INFO_E_INVALID_DOMAIN = -1,
+    INFO_E_UNKOWN_ERROR = -2
+} info_error;
+
+struct idevice_info_error {
+    info_error info_error;
+    idevice_error_t idevice_error;
+    lockdownd_error_t lockdownd_error;
+    FILE *error_message;
+} const default_idevice_info_error = { 
+    .info_error = INFO_E_UNKOWN_ERROR,
+    .idevice_error = IDEVICE_E_UNKNOWN_ERROR,
+    .lockdownd_error = LOCKDOWN_E_UNKNOWN_ERROR,
+    .error_message = NULL 
+};
+
+void idevice_info(struct idevice_info_options options, struct idevice_info_error* error, FILE *stream_out);
 
 #endif /* info_h */

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,20 @@
+const { stub } = require("sinon");
+
+exports.initStubs = (cp) => {  
+    return {
+        fork: cp.fork = stub(),
+        send: stub(),
+        disconnect: stub()
+    }
+}
+
+exports.initSpies = (stubs) => {
+    return {
+    child: {
+        fork: stubs.fork,
+        send: stubs.send,
+        disconnect: stubs.disconnect
+    }}
+}
+
+exports.stubChildOn = (error, devicelist) => (text, callback) => callback({error: error, data: devicelist});

--- a/test/idevice_id.spec.js
+++ b/test/idevice_id.spec.js
@@ -1,44 +1,26 @@
 
 const { id } = require('../index');
 const cp = require('child_process');
-let assert = require('assert');
 const { expect } = require('chai');
 const { 
     UnkownErrror,
     CannotRetrieveDeviceListError,
     CannotMallocMemoryError,
     CannotReallocMemoryError } = require('../index');
-const { stub } = require('sinon');
 const { native_id_errors } = require('../lib/idevice_id');
+const { initSpies, initStubs, stubChildOn } = require('./helpers');
 
 
 describe('Test idevice_id', () => {
-    
-    const stubChildOn = (error, devicelist) =>  (text, callback) => callback({error: error, data: devicelist});
+
     const stubDeviceList = {usblist: ['abcdef1234566'], networklist: ['1234566abcdef']};
 
     let stubs = {};
     let spies = {};
-    const initStubs = () => {  
-        stubs = {
-            fork: cp.fork = stub(),
-            send: stub(),
-            disconnect: stub()
-        }
-    }
-
-    const initSpies = () => {
-        spies = {
-        child: {
-            fork: stubs.fork,
-            send: stubs.send,
-            disconnect: stubs.disconnect
-        }}
-    }
   
     beforeEach(() => {
-        initStubs();
-        initSpies();
+        stubs = initStubs(cp);
+        spies = initSpies(stubs);
     });
 
     it('id retrieve the list successfully', () => {

--- a/test/idevice_info.spec.js
+++ b/test/idevice_info.spec.js
@@ -1,0 +1,199 @@
+const { initStubs, initSpies, stubChildOn } = require('./helpers');
+const cp = require('child_process');
+const { native_lockdown_errors, native_idevice_errors } = require('../lib/errors');
+const { native_idevice_info_errors } = require('../lib/idevice_info');
+const { info, LockdownError, IdeviceNoDeviceFoundError, InfoInvalidDomainError, InfoUnkownError } = require('../index');
+const { expect } = require('chai');
+
+const batteryPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BatteryCurrentCapacity</key>
+	<integer>55</integer>
+	<key>BatteryIsCharging</key>
+	<false/>
+	<key>ExternalChargeCapable</key>
+	<true/>
+	<key>ExternalConnected</key>
+	<false/>
+	<key>FullyCharged</key>
+	<false/>
+	<key>GasGaugeCapability</key>
+	<true/>
+	<key>HasBattery</key>
+	<true/>
+</dict>
+</plist>
+`
+
+
+describe('idevice_info tests', () => {
+    const expectedBatteryInfo = {
+        BatteryCurrentCapacity: 55,
+        BatteryIsCharging: false,
+        ExternalChargeCapable: true,
+        ExternalConnected: false,
+        FullyCharged: false,
+        GasGaugeCapability: true,
+        HasBattery: true
+    }
+    const stubErrors = (infoError, ideviceError, lockdownError, message) => { return {infoError: infoError, ideviceError: ideviceError, lockdownError: lockdownError, errorMessage: message} }
+    let stubs = {};
+    let spies = {};
+
+    beforeEach(() => {
+        stubs = initStubs(cp);
+        spies = initSpies(stubs);
+    });
+
+    it('info must retrieve information as an object', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_idevice_info_errors.INFO_E_ESUCCESS,
+                    native_idevice_errors.IDEVICE_E_SUCCESS, 
+                    native_lockdown_errors.LOCKDOWN_E_SUCCESS, 
+                    ''
+                ), 
+                batteryPlist),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        info({}, (error, info) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.null;
+            expect(info).to.eql(expectedBatteryInfo);
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('info must retrieve information as an object if options is not defined', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                native_idevice_info_errors.INFO_E_ESUCCESS,
+                native_idevice_errors.IDEVICE_E_SUCCESS,
+                native_lockdown_errors.LOCKDOWN_E_SUCCESS, 
+                ''
+            ),
+                batteryPlist),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        info((error, info) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.null;
+            expect(info).to.eql(expectedBatteryInfo);
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+
+    it('info must return error if device is not found', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_idevice_info_errors.INFO_E_UNKOWN_ERROR,
+                    native_idevice_errors.IDEVICE_E_NO_DEVICE,
+                    native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR, 
+                    ''
+                ), 
+                batteryPlist),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        info({}, (error, info) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(IdeviceNoDeviceFoundError);
+            expect(info).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('info must return error if invalid domain is provided', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_idevice_info_errors.INFO_E_INVALID_DOMAIN,
+                    native_idevice_errors.IDEVICE_E_UNKNOWN_ERROR,
+                    native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR,
+                    ''
+                ), 
+                batteryPlist),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        info({}, (error, info) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(InfoInvalidDomainError);
+            expect(info).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('info must return error if imobiledevice lockdown fails', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                native_idevice_info_errors.INFO_E_UNKOWN_ERROR,
+                native_idevice_errors.IDEVICE_E_SUCCESS,
+                native_lockdown_errors.LOCKDOWN_E_INVALID_SERVICE, ''), 
+                batteryPlist),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        info({}, (error, info) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(LockdownError);
+            expect(info).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('info must return an unkown error', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                native_idevice_info_errors.INFO_E_UNKOWN_ERROR,
+                native_idevice_errors.IDEVICE_E_UNKNOWN_ERROR,
+                native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR, 
+                ''), 
+                batteryPlist),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        info({}, (error, info) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(InfoUnkownError);
+    
+            expect(info).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,6 +140,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -914,6 +919,15 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
   integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
+plist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.2.tgz#74bbf011124b90421c22d15779cee60060ba95bc"
+  integrity sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==
+  dependencies:
+    base64-js "^1.5.1"
+    xmlbuilder "^9.0.7"
+    xmldom "^0.5.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -1227,6 +1241,16 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+xmlbuilder@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
+xmldom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
- Change behavior of idevice_info:

    - Now idevice_info is going to return an object instead of a string
      with the device data.
    - The errors that idevice_info can return are:
      InfoNodeviceFoundError, InfoInvalidDomainError, InfoUnkownError or
      LockdownError.

- Force to idevice_info native to return data as xml/plist format.

- Use plist parser for parsing plists as javascript objeccts.

- Implement idevice_info tests.