### PR TITLE
GH-33: support udid and debug options in pair method.

### DIFF
--- a/examples/idevicepair_pair.js
+++ b/examples/idevicepair_pair.js
@@ -1,10 +1,7 @@
 const imobiledevice = require('../index');
 
 
-imobiledevice.pair("pair", (error, info) => {
-    if (error) {
-        console.error(`Error in callign ideviceinfo: ${error}`);
-    } else {
-        console.log(`idevicepair: ${info}`);
-    }
+imobiledevice.pair.pair({udid: '00008020-00536054332632021'}, (error, info) => {
+    console.error(`Error in callign idevice_pair: `, error);
+    console.log(`idevicepair: ${info}`);
 });

--- a/examples/idevicepair_validate.js
+++ b/examples/idevicepair_validate.js
@@ -1,10 +1,7 @@
 const imobiledevice = require('../index');
 
 
-imobiledevice.pair("validate", (error, info) => {
-    if (error) {
-        console.error(`Error in callign ideviceinfo: ${error}`);
-    } else {
-        console.log(`idevicepair: ${info}`);
-    }
+imobiledevice.pair.validate((error, info) => {
+    console.error(`Error in callign ideviceinfo`, error);
+    console.log(`pair validated with udid: ${info}`);
 });

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -98,15 +98,112 @@ const native_lockdown_errors_dict = {
 };
 
 /**
+ * Libimobiledevice lockdown error —cannot validate due to a passcode is set.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name - Error name.
+ * @property {string} udid - Device udid.
+ * @property {number} code - Error code.
+ */
+exports.LockdownPasswordProtectedError = class LockdownPasswordProtectedError extends Error {
+	/**
+	 * 
+	 * @param {string} message 
+	 * @param {string} udid 
+	 */
+	constructor(message, udid) {
+		super(message);
+		this.udid = udid;
+		this.name = 'LockdownPasswordProtectedError';
+		this.code = native_lockdown_errors.LOCKDOWN_E_PASSWORD_PROTECTED;
+	}
+}
+
+/**
+ * Libimobiledevice lockdown error —device is not paired with this host.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name - Error name.
+ * @property {string} udid - Device udid.
+ * @property {number} code - Error code.
+ */
+exports.LockdownInvalidHostIdError = class LockdownInvalidHostIdError extends Error {
+	/**
+	 * 
+	 * @param {string} message 
+	 * @param {string} udid 
+	 */
+	constructor(message, udid) {
+		super(message);
+		this.udid = udid;
+		this.name = 'LockdownInvalidHostIdError';
+		this.code = native_lockdown_errors.LOCKDOWN_E_INVALID_HOST_ID;
+	}
+}
+
+/**
+ * Libimobiledevice lockdown error —user must accept the trust dialog on the screen device, then attempt to pair again.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name - Error name.
+ * @property {string} udid - Device udid.
+ * @property {number} code - Error code.
+ */
+exports.LockdownPairingDialongResponsoPendingError = class LockdownPairingDialongResponsoPendingError extends Error {
+	/**
+	 * 
+	 * @param {string} message 
+	 * @param {string} udid 
+	 */
+	constructor(message, udid) {
+		super(message);
+		this.udid = udid;
+		this.name = 'LockdownPairingDialongResponsoPendingError';
+		this.code = native_lockdown_errors.LOCKDOWN_E_PAIRING_DIALOG_RESPONSE_PENDING;
+	}
+}
+
+/**
+ * Libimobiledevice lockdown error —user denied the trust dialog.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name - Error name.
+ * @property {string} udid - Device udid.
+ * @property {number} code - Error code.
+ */
+exports.LockdownUserDeniedPairingError = class LockdownUserDeniedPairingError extends Error {
+	/**
+	 * 
+	 * @param {string} message 
+	 * @param {string} udid 
+	 */
+	constructor(message, udid) {
+		super(message);
+		this.udid = udid;
+		this.name = 'LockdownUserDeniedPairingError';
+		this.code = native_lockdown_errors.LOCKDOWN_E_USER_DENIED_PAIRING;
+	}
+}
+
+/**
  * Libimobiledevice lockdown error.
  * @class
  * @constructor
  * @public
- * @property {string} name
+ * @property {string} name - Error name.
  * @property {string} type - The different type of lockdown errors as string defined in native_lockdown_errors_dict
  * @property {number} code - The different code errors of lockdown as a number.
  */
 exports.LockdownError = class LockdownError extends Error {
+	/**
+	 * 
+	 * @param {string} message 
+	 * @param {number} code 
+	 */
     constructor(message, code) {
         super(message);
 		this.name = 'LockdownError';
@@ -121,10 +218,14 @@ exports.LockdownError = class LockdownError extends Error {
  * @class
  * @constructor
  * @public
- * @property {string} name
- * @property {number} code
+ * @property {string} name - Error name.
+ * @property {number} code - Error code.
  */
 exports.IdeviceNoDeviceFoundError = class IdeviceNoDeviceFoundError extends Error {
+	/**
+	 * 
+	 * @param {string} message 
+	 */
     constructor(message) {
         super(message);
 		this.name = 'IdeviceNoDeviceFoundError';
@@ -137,9 +238,13 @@ exports.IdeviceNoDeviceFoundError = class IdeviceNoDeviceFoundError extends Erro
  * @class
  * @constructor
  * @public
- * @property {string} name
+ * @property {string} name - Error name.
  */
 exports.UnkownErrror = class UnkownError extends Error {
+	/**
+	 * 
+	 * @param {string} message 
+	 */
     constructor(message) {
         super(`Unkown error: ${message}`);
         this.name = 'UnkownErrror';

--- a/lib/idevice_info.js
+++ b/lib/idevice_info.js
@@ -8,19 +8,50 @@ const native_idevice_info_errors = {
     INFO_E_UNKOWN_ERROR: -2
 }
 
+/**
+ * Ideviceinfo error —invalid domain error.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name - Error name.
+ * @property {number} code - Error code.
+ */
 class InfoInvalidDomainError extends Error {
+	/**
+	 * 
+	 * @param {string} message 
+	 */
     constructor(message) {
         super(message);
+		this.name = 'InfoInvalidDomainError';
         this.code = native_idevice_info_errors.INFO_E_INVALID_DOMAIN;
     }
 }
 
+/**
+ * Ideviceinfo error —unkown error.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name - Error name.
+ * @property {number} infoErrorCode - Info error code.
+ * @property {number} ideviceErrorCode - Idevice error code.
+ * @property {number} lockdownErrorCode - Lockdown error code.
+ */
 class InfoUnkownError extends Error {
-    constructor(message, infoCode, ideviceError, lockdownCode) {
+	/**
+	 * 
+	 * @param {string} message
+	 * @param {number} infoErrorCode
+	 * @param {number} ideviceErrorCode
+	 * @param {number} lockdownErrorCode
+	 */
+    constructor(message, infoErrorCode, ideviceErrorCode, lockdownErrorCode) {
         super(message);
-        this.infoCode = infoCode;
-		this.ideviceError = ideviceError;
-		this.lockdownCode = lockdownCode;
+		this.name = 'InfoUnkownError'
+        this.infoErrorCode = infoErrorCode;
+		this.ideviceErrorCode = ideviceErrorCode;
+		this.lockdownErrorCode = lockdownErrorCode;
     }
 }
 

--- a/lib/idevice_pair.js
+++ b/lib/idevice_pair.js
@@ -1,0 +1,143 @@
+
+const cp = require('child_process');
+const { native_idevice_errors, native_lockdown_errors, LockdownPasswordProtectedError, LockdownInvalidHostIdError, LockdownPairingDialongResponsoPendingError, LockdownUserDeniedPairingError, LockdownError, IdeviceNoDeviceFoundError } = require('./errors');
+
+
+const native_pair_errors = {
+    PAIR_E_SUCCESS: 0,
+    PAIR_E_INVALID_COMMAND: -1,
+    PAIR_E_UNKOWN_ERROR: -2
+}
+
+/**
+ * Idevicepair error —Invalid command provided.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name - Error name.
+ * @property {number} code - Error code.
+ */
+class PairInvalidCommandError extends Error {
+    /**
+     * 
+     * @param {string} message 
+     */
+    constructor(message) {
+        super(message);
+        this.name = 'PairInvalidCommandError';
+        this.code = native_pair_errors.PAIR_E_INVALID_COMMAND;
+    }
+}
+
+/**
+ * Idevicepair error —Invalid command provided.
+ * @class
+ * @constructor
+ * @public
+ * @property {string} name - Error name.
+ * @property {number} pairErrorCode - Pair error code.
+ * @property {number} ideviceErrorCode - Idevice error code.
+ * @property {number} lockdownErrorCode - Lockdown error code.
+ */
+class PairUnkownError extends Error {
+    /**
+     * 
+     * @param {string} message 
+     * @param {number} pairErrorCode 
+     * @param {number} ideviceErrorCode 
+     * @param {number} lockdownErrorCode 
+     */
+    constructor(message, pairErrorCode, ideviceErrorCode, lockdownErrorCode) {
+        super(message);
+        this.name = 'PairUnkownError';
+        this.pairErrorCode = pairErrorCode;
+		this.ideviceErrorCode = ideviceErrorCode;
+		this.lockdownErrorCode = lockdownErrorCode;
+    }
+}
+
+const getPairParameters = (command, options, callback) => {
+	if (typeof options === "function") {
+		callback = options;
+		options = null;
+	}
+	let pOptions = {
+		debug: false,
+		command: command,
+		udid: null,
+	};
+	if(options) {
+		pOptions.debug = options.debug || false;
+		pOptions.udid = options.udid || null;
+	}
+	return {pOptions: pOptions, pCallback: callback};
+}
+
+exports.native_pair_errors = native_pair_errors;
+exports.PairInvalidCommandError = PairInvalidCommandError;
+exports.PairUnkownError = PairUnkownError;
+exports.getPairParameters = getPairParameters;
+
+exports.idevice_pair = function(options, callback) {
+	const child = cp.fork(`${__dirname}/workers/pair_worker`)
+	child.send(options)
+	child.on('message', res => {
+        let pairError = res.error.pairError;
+        let ideviceError = res.error.ideviceError;
+        let lockdownError = res.error.lockdownError;
+        let errorMessage = res.error.errorMessage;
+        let udid = res.error.udid;
+
+        switch(true) {
+            // SUCCESS: list and systembuid
+            case (pairError === native_pair_errors.PAIR_E_SUCCESS
+                && ideviceError === native_idevice_errors.IDEVICE_E_UNKNOWN_ERROR 
+                && lockdownError === native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR):
+                callback(null, res.data);
+                break;
+            // SUCCESS: hostid
+            case (pairError === native_pair_errors.PAIR_E_SUCCESS
+                && ideviceError === native_idevice_errors.IDEVICE_E_SUCCESS 
+                && lockdownError === native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR):
+                callback(null, res.data);
+                break;
+            // SUCCESS: pair, validate, unpair commands
+            case (pairError === native_pair_errors.PAIR_E_SUCCESS 
+                && ideviceError === native_idevice_errors.IDEVICE_E_SUCCESS 
+                && lockdownError === native_lockdown_errors.LOCKDOWN_E_SUCCESS):
+                callback(null, res.data);
+                break;
+            case (pairError === native_pair_errors.PAIR_E_INVALID_COMMAND 
+                && ideviceError === native_idevice_errors.IDEVICE_E_UNKNOWN_ERROR 
+                && lockdownError === native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR):
+                callback(new PairInvalidCommandError(errorMessage), null);
+                break;
+            case (ideviceError === native_idevice_errors.IDEVICE_E_NO_DEVICE):
+                callback(new IdeviceNoDeviceFoundError(errorMessage), null);
+                break;
+            case (lockdownError === native_lockdown_errors.LOCKDOWN_E_PASSWORD_PROTECTED):
+                callback(new LockdownPasswordProtectedError(errorMessage, udid), null);
+                break;
+            case (lockdownError === native_lockdown_errors.LOCKDOWN_E_INVALID_HOST_ID):
+                callback(new LockdownInvalidHostIdError(errorMessage, udid), null);
+                break;
+            case (lockdownError === native_lockdown_errors.LOCKDOWN_E_PAIRING_DIALOG_RESPONSE_PENDING):
+                callback(new LockdownPairingDialongResponsoPendingError(errorMessage, udid), null);
+                break;
+            case (lockdownError === native_lockdown_errors.LOCKDOWN_E_USER_DENIED_PAIRING):
+                callback(new LockdownUserDeniedPairingError(errorMessage, udid), null);
+                break;
+            case (pairError === native_pair_errors.PAIR_E_UNKOWN_ERROR 
+                && ideviceError === native_idevice_errors.IDEVICE_E_UNKNOWN_ERROR 
+                && lockdownError !== native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR):
+                callback(new LockdownError(errorMessage, lockdownError), null);
+                break;
+            default:
+                callback(new PairUnkownError(errorMessage, pairError, ideviceError, lockdownError), null);
+                break;
+
+        }
+		child.disconnect()
+	})
+	return child
+}

--- a/lib/pair_worker.js
+++ b/lib/pair_worker.js
@@ -1,8 +1,0 @@
-const lib = require(`${__dirname}/../build/Release/imobiledevice.node`)
-
-process.on('message', options => {
-	lib.idevice_pair(options, (err, data) => {
-		if (err) process.send({err: err})
-		else process.send({data: data})
-	})
-})

--- a/lib/workers/pair_worker.js
+++ b/lib/workers/pair_worker.js
@@ -1,0 +1,7 @@
+const lib = require(`${__dirname}/../../build/Release/imobiledevice.node`)
+
+process.on('message', options => {
+	lib.idevice_pair(options, (error, data) => {
+		process.send({error: error, data: data});
+	});
+});

--- a/src/idevice/pair.c
+++ b/src/idevice/pair.c
@@ -10,41 +10,45 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <libimobiledevice/libimobiledevice.h>
-#include <libimobiledevice/lockdown.h>
-
 static char *udid = NULL;
 
-static void print_error_message(lockdownd_error_t err, FILE *stream_err)
+static void print_error_message(lockdownd_error_t lerr, struct idevice_pair_error *error)
 {
-	switch (err) {
+	switch (lerr) {
 		case LOCKDOWN_E_PASSWORD_PROTECTED:
-			fprintf(stream_err, "ERROR: Could not validate with device %s because a passcode is set. Please enter the passcode on the device and retry.\n", udid);
+			fprintf(error->error_message, "ERROR: Could not validate with device %s because a passcode is set. Please enter the passcode on the device and retry.\n", udid);
+			fprintf(error->udid, "%s", udid);
 			break;
 		case LOCKDOWN_E_INVALID_HOST_ID:
-			fprintf(stream_err, "ERROR: Device %s is not paired with this host\n", udid);
+			fprintf(error->error_message, "ERROR: Device %s is not paired with this host\n", udid);
+			fprintf(error->udid, "%s", udid);
 			break;
 		case LOCKDOWN_E_PAIRING_DIALOG_RESPONSE_PENDING:
-			fprintf(stream_err, "ERROR: Please accept the trust dialog on the screen of device %s, then attempt to pair again.\n", udid);
+			fprintf(error->error_message, "ERROR: Please accept the trust dialog on the screen of device %s, then attempt to pair again.\n", udid);
+			fprintf(error->udid, "%s", udid);
 			break;
 		case LOCKDOWN_E_USER_DENIED_PAIRING:
-			fprintf(stream_err, "ERROR: Device %s said that the user denied the trust dialog.\n", udid);
+			fprintf(error->error_message, "ERROR: Device %s said that the user denied the trust dialog.\n", udid);
+			fprintf(error->udid, "%s", udid);
 			break;
 		default:
-			fprintf(stream_err, "ERROR: Device %s returned unhandled error code %d\n", udid, err);
+			fprintf(error->error_message, "ERROR: Device %s returned unhandled error code %d\n", udid, lerr);
+			fprintf(error->udid, "%s", udid);
 			break;
 	}
 }
 
-int idevice_pair(char *cmd, FILE *stream_err, FILE *stream_out)
+int idevice_pair(struct idevice_pair_options options, struct idevice_pair_error *error, FILE *stream_out)
 {
 	lockdownd_client_t client = NULL;
 	idevice_t device = NULL;
-	idevice_error_t ret = IDEVICE_E_UNKNOWN_ERROR;
-	lockdownd_error_t lerr;
+	error->idevice_error = IDEVICE_E_UNKNOWN_ERROR;
+	error->lockdownd_error = LOCKDOWN_E_UNKNOWN_ERROR;
 	int result;
-
+	char *cmd = options.command;
 	char *type = NULL;
+	if(options.udid) udid = options.udid;
+
 	typedef enum {
 		OP_NONE = 0, OP_PAIR, OP_VALIDATE, OP_UNPAIR, OP_LIST, OP_HOSTID, OP_SYSTEMBUID
 	} op_t;
@@ -63,15 +67,15 @@ int idevice_pair(char *cmd, FILE *stream_err, FILE *stream_out)
 	} else if (!strcmp(cmd, "systembuid")) {
 		op = OP_SYSTEMBUID;
 	} else {
-		fprintf(stream_err, "ERROR: Invalid command '%s' specified\n", cmd);
+		fprintf(error->error_message, "ERROR: Invalid command '%s' specified\n", cmd);
+		error->pair_error = PAIR_E_INVALID_COMMAND;
 		exit(EXIT_FAILURE);
 	}
 
 	if (op == OP_SYSTEMBUID) {
 		char *systembuid = NULL;
 		userpref_read_system_buid(&systembuid);
-
-		fprintf(stream_out, "%s\n", systembuid);
+		fprintf(stream_out, "%s", systembuid);
 
 		if (systembuid)
 			free(systembuid);
@@ -96,24 +100,25 @@ int idevice_pair(char *cmd, FILE *stream_err, FILE *stream_out)
 	}
 
 	if (udid) {
-		ret = idevice_new(&device, udid);
-		free(udid);
-		udid = NULL;
-		if (ret != IDEVICE_E_SUCCESS) {
-			fprintf(stream_err, "No device found with udid %s, is it plugged in?\n", udid);
+		error->idevice_error = idevice_new(&device, udid);
+		if (error->idevice_error != IDEVICE_E_SUCCESS) {
+			fprintf(error->error_message, "No device found with udid %s, is it plugged in?\n", udid);
+			fprintf(error->udid, "%s", udid);
+			free(udid);
+			udid = NULL;
 			return EXIT_FAILURE;
 		}
 	} else {
-		ret = idevice_new(&device, NULL);
-		if (ret != IDEVICE_E_SUCCESS) {
-			fprintf(stream_err, "No device found, is it plugged in?\n");
+		error->idevice_error = idevice_new(&device, NULL);
+		if (error->idevice_error != IDEVICE_E_SUCCESS) {
+			fprintf(error->error_message, "No device found, is it plugged in?\n");
 			return EXIT_FAILURE;
 		}
 	}
 
-	ret = idevice_get_udid(device, &udid);
-	if (ret != IDEVICE_E_SUCCESS) {
-		fprintf(stream_err, "ERROR: Could not get device udid, error code %d\n", ret);
+	error->idevice_error = idevice_get_udid(device, &udid);
+	if (error->idevice_error != IDEVICE_E_SUCCESS) {
+		fprintf(error->error_message, "ERROR: Could not get device udid, error code %d\n", error->idevice_error);
 		result = EXIT_FAILURE;
 		goto leave;
 	}
@@ -125,7 +130,7 @@ int idevice_pair(char *cmd, FILE *stream_err, FILE *stream_out)
 		userpref_read_pair_record(udid, &pair_record);
 		pair_record_get_host_id(pair_record, &hostid);
 
-		fprintf(stream_out, "%s\n", hostid);
+		fprintf(stream_out, "%s", hostid);
 
 		if (hostid)
 			free(hostid);
@@ -136,23 +141,23 @@ int idevice_pair(char *cmd, FILE *stream_err, FILE *stream_out)
 		return EXIT_SUCCESS;
 	}
 
-	lerr = lockdownd_client_new(device, &client, "idevicepair");
-	if (lerr != LOCKDOWN_E_SUCCESS) {
+	error->lockdownd_error = lockdownd_client_new(device, &client, TOOL_NAME);
+	if (error->lockdownd_error != LOCKDOWN_E_SUCCESS) {
 		idevice_free(device);
-        fprintf(stream_err, "ERROR: Could not connect to lockdownd, error code %d\n", lerr);
+        fprintf(error->error_message, "ERROR: Could not connect to lockdownd, error code %d\n", error->lockdownd_error);
 		return EXIT_FAILURE;
 	}
 
 	result = EXIT_SUCCESS;
 
-	lerr = lockdownd_query_type(client, &type);
-	if (lerr != LOCKDOWN_E_SUCCESS) {
-		fprintf(stream_err, "QueryType failed, error code %d\n", lerr);
+	error->lockdownd_error = lockdownd_query_type(client, &type);
+	if (error->lockdownd_error != LOCKDOWN_E_SUCCESS) {
+		fprintf(error->error_message, "QueryType failed, error code %d\n", error->lockdownd_error);
 		result = EXIT_FAILURE;
 		goto leave;
 	} else {
 		if (strcmp("com.apple.mobile.lockdown", type)) {
-			fprintf(stream_err, "WARNING: QueryType request returned '%s'\n", type);
+			fprintf(error->error_message, "WARNING: QueryType request returned '%s'\n", type);
 		}
 		if (type) {
 			free(type);
@@ -162,34 +167,34 @@ int idevice_pair(char *cmd, FILE *stream_err, FILE *stream_out)
 	switch(op) {
 		default:
 		case OP_PAIR:
-		lerr = lockdownd_pair(client, NULL);
-		if (lerr == LOCKDOWN_E_SUCCESS) {
-			fprintf(stream_out, "SUCCESS: Paired with device %s\n", udid);
+		error->lockdownd_error = lockdownd_pair(client, NULL);
+		if (error->lockdownd_error == LOCKDOWN_E_SUCCESS) {
+			fprintf(stream_out, "%s", udid);
 		} else {
 			result = EXIT_FAILURE;
-			print_error_message(lerr, stream_err);
+			print_error_message(error->lockdownd_error, error);
 		}
 		break;
 
 		case OP_VALIDATE:
 		lockdownd_client_free(client);
 		client = NULL;
-		lerr = lockdownd_client_new_with_handshake(device, &client, TOOL_NAME);
-		if (lerr == LOCKDOWN_E_SUCCESS) {
-			fprintf(stream_out, "SUCCESS: Validated pairing with device %s\n", udid);
+		error->lockdownd_error = lockdownd_client_new_with_handshake(device, &client, TOOL_NAME);
+		if (error->lockdownd_error == LOCKDOWN_E_SUCCESS) {
+			fprintf(stream_out, "%s", udid);
 		} else {
 			result = EXIT_FAILURE;
-			print_error_message(lerr, stream_err);
+			print_error_message(error->lockdownd_error, error);
 		}
 		break;
 
 		case OP_UNPAIR:
-		lerr = lockdownd_unpair(client, NULL);
-		if (lerr == LOCKDOWN_E_SUCCESS) {
-			fprintf(stream_out, "SUCCESS: Unpaired with device %s\n", udid);
+		error->lockdownd_error = lockdownd_unpair(client, NULL);
+		if (error->lockdownd_error == LOCKDOWN_E_SUCCESS) {
+			fprintf(stream_out, "%s", udid);
 		} else {
 			result = EXIT_FAILURE;
-			print_error_message(lerr, stream_err);
+			print_error_message(error->lockdownd_error, error);
 		}
 		break;
 	}

--- a/src/idevice/pair.h
+++ b/src/idevice/pair.h
@@ -4,6 +4,39 @@
 #include <stdbool.h>
 #include "common/userpref.h"
 #include "common/common_binding.h"
+#include <libimobiledevice/libimobiledevice.h>
+#include <libimobiledevice/lockdown.h>
 
-int idevice_pair(char *cmd, FILE *stream_err, FILE *stream_out);
+typedef enum {
+    PAIR_E_SUCCESS = 0,
+    PAIR_E_INVALID_COMMAND = -1,
+    PAIR_E_UNKOWN_ERROR = -2
+} pair_error;
+
+struct idevice_pair_options {
+    bool debug;
+    char *udid;
+    char *command;
+} const default_idevice_pair_options = {.debug = false, .udid = NULL, .command = NULL};
+
+struct idevice_pair_success {
+    bool success;
+    FILE *message;
+} const default_idevice_pair_success = { .success = false, .message = NULL };
+
+struct idevice_pair_error {
+    pair_error pair_error;
+    idevice_error_t idevice_error;
+    lockdownd_error_t lockdownd_error;
+    FILE *udid;
+    FILE *error_message;
+} const default_idevice_pair_error = { 
+    .pair_error = PAIR_E_UNKOWN_ERROR,
+    .idevice_error = IDEVICE_E_UNKNOWN_ERROR,
+    .lockdownd_error = LOCKDOWN_E_UNKNOWN_ERROR,
+    .udid = NULL,
+    .error_message = NULL 
+};
+
+int idevice_pair(struct idevice_pair_options options, struct idevice_pair_error *error, FILE *stream_out);
 #endif /* pair_h */

--- a/test/idevice_info.spec.js
+++ b/test/idevice_info.spec.js
@@ -27,7 +27,6 @@ const batteryPlist = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>
 `
 
-
 describe('idevice_info tests', () => {
     const expectedBatteryInfo = {
         BatteryCurrentCapacity: 55,

--- a/test/idevice_pair.spec.js
+++ b/test/idevice_pair.spec.js
@@ -1,0 +1,357 @@
+const { initStubs, initSpies, stubChildOn } = require('./helpers');
+const cp = require('child_process');
+const { native_lockdown_errors, native_idevice_errors } = require('../lib/errors');
+const { pair, IdeviceNoDeviceFoundError, LockdownUserDeniedPairingError, LockdownPasswordProtectedError, LockdownInvalidHostIdError, LockdownPairingDialongResponsoPendingError, LockdownError } = require('../index');
+const { expect } = require('chai');
+const { native_pair_errors, PairInvalidCommandError, PairUnkownError, idevice_pair } = require('../lib/idevice_pair');
+const { match } = require("sinon");
+
+describe('idevice_pair tests', () => {
+
+    const stubErrors = (pairError, ideviceError, lockdownError, message) => { return {pairError: pairError, ideviceError: ideviceError, lockdownError: lockdownError, errorMessage: message} };
+    const defaultForkStub = (spies) => {return {
+        send: spies.child.send.returns((options) => {}),
+        on: stubChildOn(stubErrors(0, 0, 0, ''),''),
+        disconnect: spies.child.disconnect.returns(() => {})
+    }};
+    let getDefaultOptions = (command) => {return {debug: false, command: command, udid: null}; };
+    let stubs = {};
+    let spies = {};
+
+    beforeEach(() => {
+        stubs = initStubs(cp);
+        spies = initSpies(stubs);
+    });
+
+    it('id.pair.pair must be called with pair option', () => {
+        let expectedOptions = getDefaultOptions('pair');
+        const spySend = spies.child.send;
+        spies.child.fork.returns(defaultForkStub(spies));
+        pair.pair(expectedOptions, (error, udid) => {
+            expect(spySend.calledWith(match(expectedOptions))).to.equal(true);
+        });
+    });
+
+    it('id.pair.validate must be called with validate option', () => {
+        let expectedOptions = getDefaultOptions('validate');
+        const spySend = spies.child.send;
+        spies.child.fork.returns(defaultForkStub(spies));
+        pair.validate(expectedOptions, (error, udid) => {
+            expect(spySend.calledWith(match(expectedOptions))).to.equal(true);
+        });
+    });
+
+    it('id.pair.unpair must be called with unpair option', () => {
+        let expectedOptions = getDefaultOptions('unpair');
+        const spySend = spies.child.send;
+        spies.child.fork.returns(defaultForkStub(spies));
+        pair.unpair(expectedOptions, (error, udid) => {
+            expect(spySend.calledWith(match(expectedOptions))).to.equal(true);
+        });
+    });
+
+    it('id.pair.list must be called with list option', () => {
+        let expectedOptions = getDefaultOptions('list');
+        const spySend = spies.child.send;
+        spies.child.fork.returns(defaultForkStub(spies));
+        pair.list(expectedOptions, (error, udid) => {
+            expect(spySend.calledWith(match(expectedOptions))).to.equal(true);
+        });
+    });
+
+    it('id.pair.systembuid must be called with systembuid option', () => {
+        let expectedOptions = getDefaultOptions('systembuid');
+        const spySend = spies.child.send;
+        spies.child.fork.returns(defaultForkStub(spies));
+        pair.systembuid(expectedOptions, (error, udid) => {
+            expect(spySend.calledWith(match(expectedOptions))).to.equal(true);
+        });
+    });
+
+    it('id.pair.hostid must be called with hostid option', () => {
+        let expectedOptions = getDefaultOptions('hostid');
+        const spySend = spies.child.send;
+        spies.child.fork.returns(defaultForkStub(spies));
+        pair.hostid(expectedOptions, (error, udid) => {
+            expect(spySend.calledWith(match(expectedOptions))).to.equal(true);
+        });
+    });
+
+    it('id.pair.pair must pair successfully.', () => {
+        const expectedUdid = '00008020-000130543C46001F';
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                native_pair_errors.PAIR_E_SUCCESS,
+                native_idevice_errors.IDEVICE_E_SUCCESS,
+                native_lockdown_errors.LOCKDOWN_E_SUCCESS, 
+                ''
+            ),
+            expectedUdid),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({debug: false, udid: expectedUdid}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.null;
+            expect(udid).to.eql(expectedUdid);
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair.systembuid must run successfully.', () => {
+        const expectedSystembuid = '3A622A81-12F1-7348-EFB9-465774D2348B';
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                native_pair_errors.PAIR_E_SUCCESS,
+                native_idevice_errors.IDEVICE_E_UNKNOWN_ERROR,
+                native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR, 
+                ''
+            ),
+            expectedSystembuid),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.systembuid((error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.null;
+            expect(udid).to.eql(expectedSystembuid);
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair.hostid must run successfully.', () => {
+        const expectedHostid = '143A2E7E-AF31-D2E3-2446-41F4EF34EC2A';
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                native_pair_errors.PAIR_E_SUCCESS,
+                native_idevice_errors.IDEVICE_E_SUCCESS,
+                native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR, 
+                ''
+            ),
+            expectedHostid),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.hostid((error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.null;
+            expect(udid).to.eql(expectedHostid);
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair must fail with invalid command', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_pair_errors.PAIR_E_INVALID_COMMAND,
+                    native_idevice_errors.IDEVICE_E_UNKNOWN_ERROR,
+                    native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR, 
+                    ''
+                ), 
+                null),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(PairInvalidCommandError);
+            expect(udid).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair must fail with device not found', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_pair_errors.PAIR_E_UNKOWN_ERROR,
+                    native_idevice_errors.IDEVICE_E_NO_DEVICE,
+                    native_lockdown_errors.LOCKDOWN_E_UNKNOWN_ERROR, 
+                    ''
+                ), 
+                null),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(IdeviceNoDeviceFoundError);
+            expect(udid).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair must fail with device is password protected', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_pair_errors.PAIR_E_UNKOWN_ERROR,
+                    native_idevice_errors.IDEVICE_E_SUCCESS,
+                    native_lockdown_errors.LOCKDOWN_E_PASSWORD_PROTECTED, 
+                    ''
+                ), 
+                null),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(LockdownPasswordProtectedError);
+            expect(udid).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair must fail with invalid host id', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_pair_errors.PAIR_E_UNKOWN_ERROR,
+                    native_idevice_errors.IDEVICE_E_SUCCESS,
+                    native_lockdown_errors.LOCKDOWN_E_INVALID_HOST_ID, 
+                    ''
+                ), 
+                null),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(LockdownInvalidHostIdError);
+            expect(udid).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair must fail with pending pairing dialog response', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_pair_errors.PAIR_E_UNKOWN_ERROR,
+                    native_idevice_errors.IDEVICE_E_SUCCESS,
+                    native_lockdown_errors.LOCKDOWN_E_PAIRING_DIALOG_RESPONSE_PENDING, 
+                    ''
+                ), 
+                null),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(LockdownPairingDialongResponsoPendingError);
+            expect(udid).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair must fail with user denied pairing', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_pair_errors.PAIR_E_UNKOWN_ERROR,
+                    native_idevice_errors.IDEVICE_E_SUCCESS,
+                    native_lockdown_errors.LOCKDOWN_E_USER_DENIED_PAIRING, 
+                    ''
+                ), 
+                null),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(LockdownUserDeniedPairingError);
+            expect(udid).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair must fail with lockdown error', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_pair_errors.PAIR_E_UNKOWN_ERROR,
+                    native_idevice_errors.IDEVICE_E_UNKNOWN_ERROR,
+                    native_lockdown_errors.LOCKDOWN_E_INVALID_CONF, 
+                    ''
+                ), 
+                null),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(LockdownError);
+            expect(udid).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+
+    it('id.pair must fail with pair unknown error', () => {
+        const spySend = spies.child.send;
+        const spyDisconnect = spies.child.disconnect;
+        const spyFork = spies.child.fork.returns({
+            send: spySend.returns((options) => {}),
+            on: stubChildOn(stubErrors(
+                    native_pair_errors.PAIR_E_UNKOWN_ERROR,
+                    native_idevice_errors.IDEVICE_E_TIMEOUT,
+                    native_lockdown_errors.LOCKDOWN_E_INVALID_CONF, 
+                    ''
+                ), 
+                null),
+            disconnect: spyDisconnect.returns(() => {})
+        });
+
+        pair.pair({}, (error, udid) => {
+            expect(spyFork.called).to.equal(true);
+            expect(spySend.called).to.equal(true);
+            expect(error).to.be.instanceOf(PairUnkownError);
+            expect(udid).to.be.null;
+        });
+
+        expect(spyDisconnect.called).to.equal(true);
+    });
+});


### PR DESCRIPTION
- Change behaviour in pair method. Now command responsabilities have
  been splitted into 6 different calls:
  - pair.pair
  - pair.validate
  - pair.unpair
  - pair.list
  - pair.systembuid
  - pair.hostid

- Implement unit test for idevice_pair